### PR TITLE
fix: web components remount issue

### DIFF
--- a/packages/floating-vue/src/components/Popper.ts
+++ b/packages/floating-vue/src/components/Popper.ts
@@ -868,7 +868,10 @@ export default () => defineComponent({
         throw new Error('No container for popover: ' + this.container)
       }
 
-      container.appendChild(this.$_popperNode)
+      if (!container.contains(this.$_popperNode)) {
+        container.appendChild(this.$_popperNode)
+      }
+
       this.isMounted = true
     },
 


### PR DESCRIPTION
This PR fixes the issue that I've hit when using the Web Component as the popover content.

Steps to reproduce:
1. Open --> `popper node` is added to the `container` --> will call `connectedCallback` on the Web Component
2. Close --> 
3. Open --> `appendChild ` called --> `popper node` is removed and added to the `container` --> will call `disconnectedCallback` and `connectedCallback` on the Web Component

The thing is that `appendChild` moves the child from its current position to the new one if it was added to the `container` [ref](https://developer.mozilla.org/en-US/docs/Web/API/Node/appendChild) and that is exactly what is going on in the third step, and because of it the Web Component is disconnected and connected right away.
If the `container` already contains that `popper node` there is no reason to remove and add it again with `appendChild` call.

Tests passing. I've also verified if it works with the `demo-vue3` app.


